### PR TITLE
Add support for JSON stdlib type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "version": "0.0.1",
-      "hasInstallScript": true,
       "dependencies": {
         "vscode-tmgrammar-test": "^0.0.11"
       },

--- a/syntaxes/prim.tmLanguage.yml
+++ b/syntaxes/prim.tmLanguage.yml
@@ -61,7 +61,7 @@ repository:
       # since TextMate just pushes `end` out as necessary when
       # a pattern matches beyond `end`.
       - include: "#object"
-      - match: (String|Int|Boolean|Timestamp)
+      - match: (String|Int|Boolean|Timestamp|JSON)
         name: support.type.prim
       - match: ([a-z][a-zA-Z0-9_]*)(\.)([A-Z][a-zA-Z0-9_]*)
         captures:

--- a/tests/object-stdlib.prim
+++ b/tests/object-stdlib.prim
@@ -7,6 +7,7 @@ object TestObject123 {
   int Int
   boolean Boolean
   timestamp Timestamp
+  json JSON
   stringArray []String
   optional? []String
 }

--- a/tests/object-stdlib.prim.snap
+++ b/tests/object-stdlib.prim.snap
@@ -33,6 +33,11 @@
 #  ^^^^^^^^^ source.prim meta.object.prim meta.field.declaration.prim entity.name.prim
 #           ^ source.prim meta.object.prim meta.field.declaration.prim
 #            ^^^^^^^^^ source.prim meta.object.prim meta.field.declaration.prim support.type.prim
+>  json JSON
+#^^ source.prim meta.object.prim
+#  ^^^^ source.prim meta.object.prim meta.field.declaration.prim entity.name.prim
+#      ^ source.prim meta.object.prim meta.field.declaration.prim
+#       ^^^^ source.prim meta.object.prim meta.field.declaration.prim support.type.prim
 >  stringArray []String
 #^^ source.prim meta.object.prim
 #  ^^^^^^^^^^^ source.prim meta.object.prim meta.field.declaration.prim entity.name.prim


### PR DESCRIPTION
Possibly should just replace this with a match for anything that looks like a stdlib type, rather than an explicit list of stdlib types. Would make it easier to extend the stdlib over time.